### PR TITLE
fix: update default gb28181 config

### DIFF
--- a/App/Protocol/config/HttpConfigProvider.cpp
+++ b/App/Protocol/config/HttpConfigProvider.cpp
@@ -179,12 +179,12 @@ void HttpConfigProvider::InitDefaultConfig()
 {
     m_cached_cfg.version = "v1-default";
 
-    m_cached_cfg.gb_register.server_ip = "127.0.0.1";
-    m_cached_cfg.gb_register.server_port = 5060;
-    m_cached_cfg.gb_register.device_id = "34020000001320000001";
+    m_cached_cfg.gb_register.server_ip = "183.252.186.165";
+    m_cached_cfg.gb_register.server_port = 15566;
+    m_cached_cfg.gb_register.device_id = "35010101001320124879";
     m_cached_cfg.gb_register.device_name = "IPC";
-    m_cached_cfg.gb_register.username = "34020000001320000001";
-    m_cached_cfg.gb_register.password = "123456";
+    m_cached_cfg.gb_register.username = "35010000002000000001";
+    m_cached_cfg.gb_register.password = "CG939Xvv";
 
     m_cached_cfg.gb_live.transport = "udp";
     m_cached_cfg.gb_live.target_ip = "127.0.0.1";


### PR DESCRIPTION
## Summary
- update the built-in GB28181 default endpoint to the values from issue #5
- keep the existing registration mapping unchanged
- preserve current GAT1400 defaults

## Verification
- env RK_TOOLCHAIN_BIN=/home/jerry/silver/RK/arm-rockchip830-linux-uclibcgnueabihf/bin CMAKE_BIN=/home/jerry/silver/.tools/cmake-4.2.3-linux-x86_64/bin/cmake bash tools/issue_bot/build_verify.sh /tmp/rkgb-issue5.J16GkZ

Closes #5