### PR TITLE
fix: ignore self-generated dev sync PRs

### DIFF
--- a/tools/issue_bot/sync_closed_issues_to_dev.py
+++ b/tools/issue_bot/sync_closed_issues_to_dev.py
@@ -75,6 +75,9 @@ def list_pull_requests(client: GitHubClient, *, state: str) -> list[dict]:
 
 
 def pr_matches_issue(pr: dict, issue_number: int) -> bool:
+    head_ref = pr.get("head", {}).get("ref", "") or ""
+    if head_ref.startswith("automation/issue-sync-"):
+        return False
     body = pr.get("body") or ""
     title = pr.get("title") or ""
     haystack = f"{title}\n{body}"


### PR DESCRIPTION
## Summary
- prevent `issue-close-sync-dev` from matching its own `automation/issue-sync-*` pull requests as issue source PRs
- avoid self-referential merges and duplicate issue comments on later reruns

## Verification
- `python3 -m py_compile tools/issue_bot/sync_closed_issues_to_dev.py`