### PR TITLE
fix: stabilize CMake toolchain detection for 3.16

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,17 @@
 cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
+
+# Select the default RK830 cross toolchain before project() so CMake compiler
+# detection and generated rules stay consistent across 3.16.x and newer.
+set(CMAKE_SYSTEM_NAME Linux)
+
+if(NOT DEFINED CMAKE_C_COMPILER)
+    set(CMAKE_C_COMPILER "arm-rockchip830-linux-uclibcgnueabihf-gcc" CACHE FILEPATH "Default RK830 C compiler")
+endif()
+
+if(NOT DEFINED CMAKE_CXX_COMPILER)
+    set(CMAKE_CXX_COMPILER "arm-rockchip830-linux-uclibcgnueabihf-g++" CACHE FILEPATH "Default RK830 CXX compiler")
+endif()
+
 project(dgiot)
 
 #add_definitions(-Werror)
@@ -13,14 +26,18 @@ option(ATBM6012B "compile for ATBM6012B" OFF)
 option(ATBM6132 "compile for ATBM6132" OFF)
 option(AIC8800DL "compile for AIC8800DL" OFF)
 
-#系统
-SET(CMAKE_SYSTEM_NAME Linux)
+get_filename_component(RK_GB_C_COMPILER_NAME "${CMAKE_C_COMPILER}" NAME)
+get_filename_component(RK_GB_CXX_COMPILER_NAME "${CMAKE_CXX_COMPILER}" NAME)
 
-#指定编译器
-#c编译
-SET(CMAKE_C_COMPILER "arm-rockchip830-linux-uclibcgnueabihf-gcc")
-#c++编译
-SET(CMAKE_CXX_COMPILER "arm-rockchip830-linux-uclibcgnueabihf-g++")
+if(NOT RK_GB_C_COMPILER_NAME STREQUAL "arm-rockchip830-linux-uclibcgnueabihf-gcc"
+   OR NOT RK_GB_CXX_COMPILER_NAME STREQUAL "arm-rockchip830-linux-uclibcgnueabihf-g++")
+    message(FATAL_ERROR
+        "Unexpected compiler selection:\n"
+        "  C   = ${CMAKE_C_COMPILER}\n"
+        "  CXX = ${CMAKE_CXX_COMPILER}\n"
+        "This project expects the RK830 cross toolchain. "
+        "Use a fresh build directory, or pass the desired compiler paths on the first CMake configure.")
+endif()
 
 # 添加子目录
 


### PR DESCRIPTION
## Summary
- move the default RK830 toolchain selection ahead of project()
- make compiler detection and generated build rules use the same cross compiler
- fail early with a clear message when CMake is reusing an unexpected cached compiler

## Why
A colleague using CMake 3.16.3 reported unstable build results. The root cause was that the project selected CMAKE_C_COMPILER / CMAKE_CXX_COMPILER after project(), so CMake compiler detection could cache /usr/bin/cc and /usr/bin/c++, while later generated rules still used the RK cross compiler. That mismatch is version-sensitive and leads to incorrect configuration behavior.

## Verification
- fresh configure now detects /home/jerry/silver/RK/arm-rockchip830-linux-uclibcgnueabihf/bin/arm-rockchip830-linux-uclibcgnueabihf-gcc and the matching g++ during the compiler check
- isolated cross build still completes through compilation and stops only at the existing historical linker issues: -lManager, -lInfra, -lExchanger, -ljson, -lDG_crypto, -lDebugInfo, -lOnvif